### PR TITLE
Allow unknown activity type.

### DIFF
--- a/src/models/activities.rs
+++ b/src/models/activities.rs
@@ -130,5 +130,6 @@ pub enum ActivityType {
     Windsurf,
     Workout,
     Yoga,
+    #[serde(other)]
     Unknown,
 }

--- a/src/models/activities.rs
+++ b/src/models/activities.rs
@@ -133,3 +133,14 @@ pub enum ActivityType {
     #[serde(other)]
     Unknown,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_unknown_activity_to_unknown() {
+        let activity = serde_json::from_str(r#""HighIntensityIntervalTraining""#);
+        assert!(matches!(activity, Ok(ActivityType::Unknown)));
+    }
+}


### PR DESCRIPTION
Allow unknown activity types, mapping them to Unknown variant.

Without this modification, I've got following error.
```
called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Decode, source: Error("unknown variant `HighIntensityIntervalTraining`, expected one of `Rowing`, `Run`, `Walk`, `WeightTraining`, `Ride`, `Swim`, `Hike`, `AlpineSki`, `BackcountrySki`, `Canoeing`, `Crossfit`, `EBikeRide`, `Elliptical`, `IceSkate`, `InlineSkate`, `Kayaking`, `Kitesurf`, `NordicSki`, `RockClimbing`, `RollerSki`, `Snowboard`, `Snowshoe`, `StairStepper`, `StandUpPaddling`, `Surfing`, `Windsurf`, `Workout`, `Yoga`, `Unknown`", line: 1, column: 21424) }
```